### PR TITLE
Fixes #13: Addressing Encounter.type issue, adding profile and valueset

### DIFF
--- a/StructureDefinition/no-helseapi-Encounter.structuredefinition-profile.xml
+++ b/StructureDefinition/no-helseapi-Encounter.structuredefinition-profile.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="no-helseapi-Encounter" />
+  <url value="http://hl7.no/fhir/StructureDefinition/no-helseapi-Encounter" />
+  <name value="NoHelseAPIEncounter" />
+  <status value="draft" />
+  <fhirVersion value="4.0.0" />
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Encounter" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/no-basis-Encounter" />
+  <snapshot>
+    <element id="Encounter">
+      <path value="Encounter" />
+      <short value="An interaction during which services are provided to the patient" />
+      <definition value="An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or assessing the health status of a patient." />
+      <min value="0" />
+      <max value="*" />
+      <type>
+        <code value="Encounter" />
+      </type>
+    </element>
+    <element id="Encounter.type">
+      <path value="Encounter.type" />
+      <short value="Specific type of encounter" />
+      <definition value="The specific type of encounter." />
+      <min value="1" />
+      <max value="*" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="required" />
+        <valueSet value="https://hl7.no/fhir/ValueSet/valueset-encounter-type" /> <!-- Custom ValueSet URL from HL7 fhir ValueSet encounter-type used-->
+      </binding>
+    </element>
+    <!-- Add other elements as needed -->
+  </snapshot>
+</StructureDefinition>

--- a/ValueSet/no-helseapi-encounter-type.valueset.xml
+++ b/ValueSet/no-helseapi-encounter-type.valueset.xml
@@ -1,0 +1,41 @@
+<ValueSet xmlns="http://hl7.org/fhir">
+  <id value="no-helseapi-encounter-type" />
+  <name value="HelseAPIEncounterType" />
+  <url value="https://hl7.no/fhir/ValueSet/no-helseapi-encounter-type" />
+  <title value="HelseAPI Encounter Type" />
+  <status value="active" /> <!-- Active not draft?or?test -->
+  <publisher value="Norsk Helsenett"/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166" />
+      <code value="NO" />
+      <display value="Norway" />
+    </coding>
+  </jurisdiction>
+  <compose>
+    <include>
+      <system value="http://snomed.info/sct" />
+      <concept>
+        <code value="4525004" />
+        <display value="Emergency department patient visit" />
+      </concept>
+      <concept>
+        <code value="50849002" />
+        <display value="Emergency room admission" />
+      </concept>
+      <!-- Add other SNOMED CT codes as needed -->
+    </include>
+    <include>
+      <system value="https://volven.no" />
+      <concept>
+        <code value="8432" />
+        <display value="NPR Contact type" />
+      </concept>
+      <concept>
+        <code value="8240" />
+        <display value="Contact type" />
+      </concept>
+      <!-- Add other Volven codes as needed -->
+    </include>
+  </compose>
+</ValueSet>


### PR DESCRIPTION
Addressed Encounter.type as described in **issue #13.** A new ValueSet for `Encounter.type` has been defined to support the use in the national area profile and Health API. The ValueSet includes codes from both SNOMED CT and Volven systems.
 ValueSet URL: `http://hl7.no/fhir/ValueSet/no-helseapi-encounter-type`

 _Included Codes_
- SNOMED CT
  - 4525004: Emergency department patient visit
  - 50849002: Emergency room admission
- Volven
  - 8432: NPR Contact type
  - 8240: Contact type

`Encounter.type` field in the Encounter profile to references this ValueSet.

The changes include:
1. Added Encounter profile for HelseAPI in profile.
2. Added Encounter type codes for HelseAPI in ValueSet.